### PR TITLE
Refactor authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,10 @@ axum-extra = { version = "0.10.0", features = ["typed-header"] }
 anyhow = "1.0.95"
 async-session = "3.0.0"
 dotenv = "0.15.0"
+sqlx = { version = "0.8.3", features = [
+    "runtime-tokio",
+    "mysql",
+    "runtime-async-std-native-tls",
+    "chrono",
+    "uuid",
+] }

--- a/migrations/20250112204942_init.down.sql
+++ b/migrations/20250112204942_init.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+DROP TABLE IF EXISTS `users`;

--- a/migrations/20250112204942_init.up.sql
+++ b/migrations/20250112204942_init.up.sql
@@ -1,0 +1,11 @@
+-- Add up migration script here
+DROP TABLE IF EXISTS `users`;
+
+CREATE TABLE `users` (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    first_name VARCHAR(64) NOT NULL,
+    last_name VARCHAR(64),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+)

--- a/migrations/20250114192358_sessions.down.sql
+++ b/migrations/20250114192358_sessions.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+DROP TABLE IF EXISTS `sessions`;

--- a/migrations/20250114192358_sessions.up.sql
+++ b/migrations/20250114192358_sessions.up.sql
@@ -1,0 +1,9 @@
+-- Add up migration script here
+DROP TABLE IF EXISTS `sessions`;
+
+CREATE TABLE `sessions` (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    session_id VARCHAR(255) NOT NULL,
+    csrf_token VARCHAR(255) NOT NULL,
+    expires_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)

--- a/src/client/google_client.rs
+++ b/src/client/google_client.rs
@@ -1,0 +1,60 @@
+use anyhow::Context;
+use http::StatusCode;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{errors::AppError, User};
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct GoogleTokenInfo {
+    audience: String,  // The audience for which the token was issued
+    email: String,     // The email associated with the access token
+    expires_in: i64,   // Expiration time in seconds
+    issued_to: String, // The client_id the token was issued to
+    user_id: String,   // The user's unique ID
+}
+
+pub struct GoogleClient<'a> {
+    http_client: &'a Client,
+}
+
+impl<'a> GoogleClient<'a> {
+    pub fn new(http_client: &'a Client) -> Self {
+        GoogleClient { http_client }
+    }
+
+    pub async fn validate_access_token(
+        &self,
+        access_token: &str,
+    ) -> Result<GoogleTokenInfo, AppError> {
+        // https://www.googleapis.com/oauth2/v1/tokeninfo
+        let google_token_info = self
+            .http_client
+            .get("https://www.googleapis.com/oauth2/v1/tokeninfo")
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .context("failed in sending request to target Url")?
+            .json::<GoogleTokenInfo>()
+            .await
+            .context("Invalid or expired token")?;
+
+        Ok(google_token_info)
+    }
+
+    pub async fn fetch_user_info(&self, access_token: &str) -> Result<User, AppError> {
+        let user_data: User = self
+            .http_client
+            .get("https://openidconnect.googleapis.com/v1/userinfo")
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .context("failed in sending request to target Url")?
+            .json::<User>()
+            .await
+            .context("failed to deserialize response as JSON")?;
+
+        Ok(user_data)
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,0 +1,1 @@
+pub mod google_client;

--- a/src/config/database.rs
+++ b/src/config/database.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+use dotenv::dotenv;
+use sqlx::{MySql, MySqlPool, Pool};
+
+use crate::errors::AppError;
+
+use super::parameter;
+
+pub struct Database {
+    pool: Pool<MySql>,
+}
+
+#[async_trait]
+pub trait DatabaseTrait {
+    async fn init() -> Result<Self, AppError>
+    where
+        Self: Sized;
+    fn get_pool(&self) -> &Pool<MySql>;
+}
+
+#[async_trait]
+impl DatabaseTrait for Database {
+    async fn init() -> Result<Self, AppError> {
+        let database_url = parameter::get("DATABASE_URL");
+        let pool = MySqlPool::connect(&database_url).await?;
+        Ok(Self { pool })
+    }
+
+    fn get_pool(&self) -> &Pool<MySql> {
+        &self.pool
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,2 @@
+mod database;
+mod parameter;

--- a/src/config/parameter.rs
+++ b/src/config/parameter.rs
@@ -1,0 +1,11 @@
+use dotenv;
+
+pub fn init() {
+    dotenv::dotenv().ok().expect("Failed to load .env file");
+}
+
+pub fn get(parameter: &str) -> String {
+    let env_parameter = std::env::var(parameter)
+        .expect(&format!("{} is not defined in the environment.", parameter));
+    return env_parameter;
+}

--- a/src/handler/auth_handler.rs
+++ b/src/handler/auth_handler.rs
@@ -50,11 +50,9 @@ pub async fn google_auth(
     .execute(&app_state.db)
     .await?;
 
-    // Attach the session cookie to the response header
-    let cookies = [
-        // format!("{COOKIE_NAME}={cookie}; SameSite=None; HttpOnly; Secure; Path=/"),
-        format!("{SESSION_COOKIE_NAME}={session_id}; SameSite=Lax; HttpOnly; Secure; Path=/"),
-    ];
+    let cookies = [format!(
+        "{SESSION_COOKIE_NAME}={session_id}; SameSite=Lax; HttpOnly; Secure; Path=/"
+    )];
     let mut headers = HeaderMap::new();
     for cookie in cookies {
         headers.append(

--- a/src/handler/auth_handler.rs
+++ b/src/handler/auth_handler.rs
@@ -1,0 +1,193 @@
+use anyhow::{anyhow, Context};
+use async_session::{base64, MemoryStore, Session, SessionStore};
+use axum::{
+    extract::{Query, State},
+    http::{header::SET_COOKIE, HeaderMap},
+    response::{IntoResponse, Redirect},
+};
+use axum_extra::{headers, TypedHeader};
+use chrono::{DateTime, Duration, Utc};
+use oauth2::{
+    basic::BasicClient, reqwest::async_http_client, AuthorizationCode, CsrfToken, Scope,
+    TokenResponse,
+};
+use rand::RngCore;
+
+use crate::{errors::AppError, AppState, AuthRequest, User};
+
+static SESSION_COOKIE_NAME: &str = "SESSION";
+
+pub async fn google_auth(
+    State(client): State<BasicClient>,
+    State(app_state): State<AppState>,
+) -> Result<impl IntoResponse, AppError> {
+    let (auth_url, csrf_token) = client
+        .authorize_url(CsrfToken::new_random)
+        .add_scope(Scope::new(
+            std::env::var("GOOGLE_EMAIL_SCOPE").context("Missing GOOGLE_EMAIL_SCOPE!")?,
+        ))
+        .add_scope(Scope::new(
+            std::env::var("GOOGLE_PROFILE_SCOPE").context("Missing GOOGLE_PROFILE_SCOPE!")?,
+        ))
+        .add_extra_param("access_type", "offline")
+        .add_extra_param("prompt", "consent")
+        .url();
+
+    let session_id = generate_session_id();
+    let csrf_token_secret = csrf_token.secret();
+    let expires_at = Utc::now() + Duration::hours(1);
+
+    // Store CSRF token
+    sqlx::query!(
+        r#"
+            INSERT INTO sessions (session_id, csrf_token, expires_at)
+            VALUES (?, ?, ?)
+            "#,
+        session_id,
+        csrf_token_secret,
+        expires_at
+    )
+    .execute(&app_state.db)
+    .await?;
+
+    // Attach the session cookie to the response header
+    let cookies = [
+        // format!("{COOKIE_NAME}={cookie}; SameSite=None; HttpOnly; Secure; Path=/"),
+        format!("{SESSION_COOKIE_NAME}={session_id}; SameSite=Lax; HttpOnly; Secure; Path=/"),
+    ];
+    let mut headers = HeaderMap::new();
+    for cookie in cookies {
+        headers.append(
+            SET_COOKIE,
+            cookie.parse().context("Failed to parse cookie")?,
+        );
+    }
+
+    Ok((headers, Redirect::to(auth_url.as_ref())))
+}
+
+pub async fn auth_callback(
+    Query(query): Query<AuthRequest>,
+    State(store): State<MemoryStore>,
+    State(oauth_client): State<BasicClient>,
+    TypedHeader(cookies): TypedHeader<headers::Cookie>,
+    State(app_state): State<AppState>,
+) -> Result<impl IntoResponse, AppError> {
+    csrf_token_validation_workflow(&app_state, &query, &cookies).await?;
+
+    // Get an auth token
+    let token = oauth_client
+        .exchange_code(AuthorizationCode::new(query.code.clone()))
+        .request_async(async_http_client)
+        .await
+        .context("failed in sending request request to authorization server")?;
+
+    let access_token = token.access_token().secret().to_string();
+
+    let refresh_token = token
+        .refresh_token()
+        .map(|rt| rt.secret().to_string())
+        .context("Refresh token missing on callback")?;
+
+    // Fetch user data from google
+    let client = reqwest::Client::new();
+    let user_data: User = client
+        .get("https://openidconnect.googleapis.com/v1/userinfo")
+        .bearer_auth(access_token.clone())
+        .send()
+        .await
+        .context("failed in sending request to target Url")?
+        .json::<User>()
+        .await
+        .context("failed to deserialize response as JSON")?;
+
+    // Create a new session filled with user data
+    let mut session = Session::new();
+    session
+        .insert("user", &user_data)
+        .context("failed in inserting serialized value into session")?;
+
+    // Store session and get corresponding cookie
+    let cookie = store
+        .store_session(session)
+        .await
+        .context("failed to store session")?
+        .context("unexpected error retrieving cookie value")?;
+
+    let cookies = [
+        format!("{SESSION_COOKIE_NAME}={cookie}; SameSite=Lax; HttpOnly; Secure; Path=/"),
+        format!("access_token={access_token}; SameSite=Lax; HttpOnly; Secure; Path=/"),
+        format!("refresh_token={refresh_token}; SameSite=Lax; HttpOnly; Secure; Path=/"),
+    ];
+    let mut headers = HeaderMap::new();
+    for cookie in cookies {
+        headers.append(
+            SET_COOKIE,
+            cookie.parse().context("Failed to parse cookie")?,
+        );
+    }
+
+    Ok((headers, Redirect::to("/")))
+}
+
+async fn csrf_token_validation_workflow(
+    app_state: &AppState,
+    auth_request: &AuthRequest,
+    cookies: &headers::Cookie,
+) -> Result<(), AppError> {
+    // Extract the cookie from the request
+    let session_id = cookies
+        .get(SESSION_COOKIE_NAME)
+        .context("unexpected error getting cookie name")?
+        .to_string();
+
+    let stored_csrf_token = get_csrf_token_by_session(app_state, &session_id)
+        .await?
+        .context("Session not found")?;
+
+    expire_session(app_state, &session_id).await?;
+
+    // Validate CSRF token is the same as the one in the auth request
+    if stored_csrf_token != auth_request.state {
+        return Err(anyhow!("CSRF token mismatch").into());
+    }
+
+    Ok(())
+}
+
+fn generate_session_id() -> String {
+    let mut key = vec![0u8; 64];
+    rand::thread_rng().fill_bytes(&mut key);
+    base64::encode(key)
+}
+
+async fn get_csrf_token_by_session(
+    app_state: &AppState,
+    session_id: &String,
+) -> Result<Option<String>, AppError> {
+    let row = sqlx::query!(
+        r#"
+            SELECT csrf_token FROM sessions WHERE session_id = ? AND expires_at > NOW()
+        "#,
+        session_id
+    )
+    .fetch_optional(&app_state.db)
+    .await?;
+
+    Ok(row.map(|r| r.csrf_token))
+}
+
+async fn expire_session(app_state: &AppState, session_id: &String) -> Result<(), AppError> {
+    sqlx::query!(
+        r#"
+            UPDATE sessions
+            SET expires_at = NOW()
+            WHERE session_id = ?
+        "#,
+        session_id
+    )
+    .execute(&app_state.db)
+    .await?;
+
+    Ok(())
+}

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -1,0 +1,1 @@
+pub mod auth_handler;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,22 @@
+mod config;
 mod errors;
+mod handler;
 mod route;
 
-use anyhow::{anyhow, Context, Result};
-use async_session::{MemoryStore, Session, SessionStore};
+use anyhow::{Context, Result};
+use async_session::{MemoryStore, SessionStore};
 use axum::{
-    extract::{FromRef, FromRequestParts, OptionalFromRequestParts, Query, State},
-    http::{header::SET_COOKIE, HeaderMap},
+    extract::{FromRef, FromRequestParts, OptionalFromRequestParts, State},
     response::{IntoResponse, Redirect, Response},
     RequestPartsExt,
 };
 use axum_extra::{headers, typed_header::TypedHeaderRejectionReason, TypedHeader};
-use chrono::{DateTime, Duration, Utc};
 use dotenv::dotenv;
 use errors::AppError;
 use http::{header, request::Parts, Method};
 use oauth2::{
-    basic::BasicClient, reqwest::async_http_client, AccessToken, AuthUrl, AuthorizationCode,
-    ClientId, ClientSecret, CsrfToken, RedirectUrl, RefreshToken, Scope, TokenResponse, TokenUrl,
+    basic::BasicClient, reqwest::async_http_client, AccessToken, AuthUrl, ClientId, ClientSecret,
+    RedirectUrl, RefreshToken, TokenResponse, TokenUrl,
 };
 use route::create_router;
 use serde::{Deserialize, Serialize};
@@ -26,7 +26,6 @@ use tower_http::cors::{Any, CorsLayer};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 static COOKIE_NAME: &str = "SESSION";
-static CSRF_TOKEN: &str = "csrf_token";
 
 #[tokio::main]
 async fn main() {
@@ -125,8 +124,6 @@ fn oauth_client() -> Result<BasicClient, AppError> {
     ))
 }
 
-// The user data we'll get back from Discord.
-// https://discord.com/developers/docs/resources/user#user-object-user-structure
 #[derive(Debug, Serialize, Deserialize)]
 struct User {
     sub: String,
@@ -144,52 +141,6 @@ async fn index(user: Option<User>) -> impl IntoResponse {
         ),
         None => "You're not logged in.\nVisit `/auth/discord` to do so.".to_string(),
     }
-}
-
-async fn google_auth(
-    State(client): State<BasicClient>,
-    State(store): State<MemoryStore>,
-) -> Result<impl IntoResponse, AppError> {
-    let (auth_url, csrf_token) = client
-        .authorize_url(CsrfToken::new_random)
-        .add_scope(Scope::new(
-            std::env::var("GOOGLE_EMAIL_SCOPE").context("Missing GOOGLE_EMAIL_SCOPE!")?,
-        ))
-        .add_scope(Scope::new(
-            std::env::var("GOOGLE_PROFILE_SCOPE").context("Missing GOOGLE_PROFILE_SCOPE!")?,
-        ))
-        .add_extra_param("access_type", "offline")
-        .add_extra_param("prompt", "consent")
-        .url();
-
-    // Create session to store csrf_token
-    let mut session = Session::new();
-    session
-        .insert(CSRF_TOKEN, &csrf_token)
-        .context("failed in inserting CSRF token into session")?;
-
-    // Store the session in MemoryStore and retrieve the session cookie
-    let cookie = store
-        .store_session(session)
-        .await
-        .context("failed to store CSRF token session")?
-        .context("unexpected error retrieving CSRF cookie value")?;
-
-    let expiry_duration = Duration::hours(1); // Default to 1 hour from now
-    let expiry_time: DateTime<Utc> = Utc::now() + expiry_duration;
-    let expires = expiry_time.to_rfc2822();
-
-    // Attach the session cookie to the response header
-    let cookie = format!(
-        "{COOKIE_NAME}={cookie}; SameSite=None; HttpOnly; Secure; Path=/; Expires={expires}"
-    );
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        SET_COOKIE,
-        cookie.parse().context("failed to parse cookie")?,
-    );
-
-    Ok((headers, Redirect::to(auth_url.as_ref())))
 }
 
 // Valid user session required. If there is none, redirect to the auth page
@@ -228,105 +179,6 @@ async fn logout(
 struct AuthRequest {
     code: String,
     state: String,
-}
-
-async fn csrf_token_validation_workflow(
-    auth_request: &AuthRequest,
-    cookies: &headers::Cookie,
-    store: &MemoryStore,
-) -> Result<(), AppError> {
-    // Extract the cookie from the request
-    let cookie = cookies
-        .get(COOKIE_NAME)
-        .context("unexpected error getting cookie name")?
-        .to_string();
-
-    // Load the session
-    let session = match store
-        .load_session(cookie)
-        .await
-        .context("failed to load session")?
-    {
-        Some(session) => session,
-        None => return Err(anyhow!("Session not found").into()),
-    };
-
-    // Extract the CSRF token from the session
-    let stored_csrf_token = session
-        .get::<CsrfToken>(CSRF_TOKEN)
-        .context("CSRF token not found in session")?
-        .to_owned();
-
-    // Cleanup the CSRF token session
-    store
-        .destroy_session(session)
-        .await
-        .context("Failed to destroy old session")?;
-
-    // Validate CSRF token is the same as the one in the auth request
-    if *stored_csrf_token.secret() != auth_request.state {
-        return Err(anyhow!("CSRF token mismatch").into());
-    }
-
-    Ok(())
-}
-
-async fn login_authorized(
-    Query(query): Query<AuthRequest>,
-    State(store): State<MemoryStore>,
-    State(oauth_client): State<BasicClient>,
-    TypedHeader(cookies): TypedHeader<headers::Cookie>,
-) -> Result<impl IntoResponse, AppError> {
-    csrf_token_validation_workflow(&query, &cookies, &store).await?;
-
-    // Get an auth token
-    let token = oauth_client
-        .exchange_code(AuthorizationCode::new(query.code.clone()))
-        .request_async(async_http_client)
-        .await
-        .context("failed in sending request request to authorization server")?;
-
-    let access_token = token.access_token().secret().to_string();
-    let refresh_token = token.refresh_token().map(|rt| rt.secret().to_string());
-
-    println!("AT: {:?}", access_token);
-    println!("RT: {:?}", refresh_token);
-    // Fetch user data from google
-    let client = reqwest::Client::new();
-    let user_data: User = client
-        .get("https://openidconnect.googleapis.com/v1/userinfo")
-        .bearer_auth(access_token)
-        .send()
-        .await
-        .context("failed in sending request to target Url")?
-        .json::<User>()
-        .await
-        .context("failed to deserialize response as JSON")?;
-
-    // Create a new session filled with user data
-    let mut session = Session::new();
-    session
-        .insert("user", &user_data)
-        .context("failed in inserting serialized value into session")?;
-
-    // Store session and get corresponding cookie
-    let cookie = store
-        .store_session(session)
-        .await
-        .context("failed to store session")?
-        .context("unexpected error retrieving cookie value")?;
-
-    // Build the cookie
-    let cookie = format!("{COOKIE_NAME}={cookie}; SameSite=Lax; HttpOnly; Secure; Path=/");
-
-    // Set cookie
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        SET_COOKIE,
-        cookie.parse().context("failed to parse cookie")?,
-    );
-
-    Ok((headers, Redirect::to("/")))
 }
 
 async fn refresh_access_token(

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -1,0 +1,50 @@
+use anyhow::Context;
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::IntoResponse,
+};
+
+use axum_extra::extract::CookieJar;
+use oauth2::{
+    basic::BasicClient, reqwest::async_http_client, AccessToken, RefreshToken, TokenResponse,
+};
+
+use crate::{client::google_client::GoogleClient, errors::AppError, AppState};
+
+pub async fn auth_2(
+    State(app_state): State<AppState>,
+    mut req: Request,
+    next: Next,
+) -> Result<impl IntoResponse, AppError> {
+    let cookies = CookieJar::from_headers(&req.headers());
+    for cookie in cookies.iter() {
+        println!(
+            "Cookie name: {}, Cookie value: {}",
+            cookie.name(),
+            cookie.value()
+        );
+    }
+    let google_client = GoogleClient::new(&app_state.http_client);
+    if let Some(access_token_cookie) = cookies.get("access_token") {
+        let access_token = access_token_cookie.value().to_string();
+        let google_token_info = google_client.validate_access_token(&access_token).await?;
+    }
+
+    // Continue validation...
+
+    Ok(next.run(req).await)
+}
+
+async fn refresh_access_token(
+    refresh_token: &str,
+    client: &BasicClient,
+) -> Result<AccessToken, AppError> {
+    let token_response = client
+        .exchange_refresh_token(&RefreshToken::new(refresh_token.to_string()))
+        .request_async(async_http_client)
+        .await
+        .context("failed to refresh access token")?;
+
+    Ok(token_response.access_token().to_owned())
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,0 +1,1 @@
+pub mod auth;

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,12 +1,15 @@
 use axum::{routing::get, Router};
 
-use crate::{google_auth, index, login_authorized, logout, protected, AppState};
+use crate::{
+    handler::auth_handler::{auth_callback, google_auth},
+    index, logout, protected, AppState,
+};
 
 pub async fn create_router(app_state: AppState) -> Router {
     Router::new()
         .route("/", get(index))
         .route("/auth/google", get(google_auth))
-        .route("/auth/authorized", get(login_authorized))
+        .route("/auth/authorized", get(auth_callback))
         .route("/protected", get(protected))
         .route("/logout", get(logout))
         .with_state(app_state)


### PR DESCRIPTION
- Setup database and parameter config
- Refactor Google OAuth setup to use database store for CSRF validation than an in-memory solution
- Add initial auth middleware (needs to be finished)
- Setup google client for authentication interactions